### PR TITLE
Related posts supported as frontmatter, share feed card include

### DIFF
--- a/_includes/feed-card.html
+++ b/_includes/feed-card.html
@@ -1,0 +1,11 @@
+<a href="{{ include.post.url | relative_url }}">
+  <div class="relative" style="height: 450px; background-color:#ECEAE7;">
+    <div class="bg-center cover" style="background-image: url('{{ include.post.thumbnail }}'); padding-bottom:100%; width:100%;">
+    </div>
+    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
+      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
+        <a class="f5 lh-title post-link" href="{{ include.post.url | relative_url }}">{{ include.post.title | escape }}</a>
+      </h2>
+    </div>
+  </div>
+</a>

--- a/_includes/feed.html
+++ b/_includes/feed.html
@@ -5,18 +5,8 @@
     <ul class="post-list">
       {% for post in site.posts %}
       {% if post.public != 1  %}
-
         <li class="fl w-third-ns w-100 w-50-m ph3">
-          <a href="{{ post.url | relative_url }}"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-            <div class="bg-center cover" style="background-image: url('{{ post.thumbnail }}'); padding-bottom:100%; width:100%;">
-            </div>
-            <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-              <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-                <a class="f5 lh-title post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
-              </h2>
-            </div>
-          </div>
-        </a>
+          {% include feed-card.html post=post %}
         </li>
       {% endif %}
       {% endfor %}

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,0 +1,22 @@
+<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">
+  {% if page.related_posts_custom_title %}
+    {{ page.related_posts_custom_title }}:
+  {% elsif page.categories contains "travelguide" %}
+    Check out more of our travel guides and itineraries:
+  {% elsif page.categories contains "review" %}
+    Check out more of our hotel reviews:
+  {% elsif page.categories contains "airbnb" %}
+    Check out more of our top Airbnb picks:
+  {% else %}
+    <!-- Check out more of our where-to-stay roundups:
+    Check out more of our travel posts: -->
+    Check out more of our posts:
+  {% endif %}
+</p>
+
+{% for related_post in page.related_posts %}
+  {% assign post = site.posts | where: 'id', related_post | first %}
+  <div class="fl w-100 w-50-ns w-50-m pr2-ns mb4">
+    {% include feed-card.html post=post %}
+  </div>
+{% endfor %}

--- a/_layouts/longform.html
+++ b/_layouts/longform.html
@@ -28,8 +28,9 @@ layout: default
     {% include disqus_comments.html %}
   {% endif %}
 </article>
-
+{% if page.related_posts.size > 0 %}
+  {% include related-posts.html %}
+{% endif %}
 </div>
-
 {% include signupform.html %}
 {% include footer.html %}

--- a/_posts/2017-10-16-why right now is actually a good and helpful time to visit mexico city.markdown
+++ b/_posts/2017-10-16-why right now is actually a good and helpful time to visit mexico city.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-10-16 00:10:36 -0400
 thumbnail: ../images/mexicocity/MexicoCity_Header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 ![](../images/mexicocity/MexicoCity_Header.jpg)

--- a/_posts/2017-10-23-san-luis-obispo-travel-guide.markdown
+++ b/_posts/2017-10-23-san-luis-obispo-travel-guide.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-10-16 00:10:36 -0400
 thumbnail: ../images/slo/SLO_Header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 ![](../images/slo/SLO_Header.jpg)

--- a/_posts/2017-10-30-granada-nicaragua-travel-guide.markdown
+++ b/_posts/2017-10-30-granada-nicaragua-travel-guide.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-10-16 00:10:36 -0400
 thumbnail: ../images/granada/NICA_HEADER.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 ![](../images/granada/NICA_HEADER.jpg)

--- a/_posts/2017-11-05-best-airbnbs-austin-texas.markdown
+++ b/_posts/2017-11-05-best-airbnbs-austin-texas.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-05 00:10:36 -0400
 thumbnail: ../images/austin/stay_header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 ![](../images/austin/stay_header.jpg)

--- a/_posts/2017-11-05-best-airbnbs-austin-texas.markdown
+++ b/_posts/2017-11-05-best-airbnbs-austin-texas.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-05 00:10:36 -0400
 thumbnail: ../images/austin/stay_header.jpg
-categories: travelguide
+categories: airbnb, list
 ---
 
 ![](../images/austin/stay_header.jpg)

--- a/_posts/2017-11-05-what-to-do-austin-texas.markdown
+++ b/_posts/2017-11-05-what-to-do-austin-texas.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-05 00:10:36 -0400
 thumbnail: ../images/austin/Austin_Header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 ![](../images/austin/Austin_Header.jpg)

--- a/_posts/2017-11-12-best-boutique-hotels-paris.markdown
+++ b/_posts/2017-11-12-best-boutique-hotels-paris.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-12 00:10:36 -0400
 thumbnail: ../images/paris/paris_header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 ![](../images/paris/paris_header.jpg)

--- a/_posts/2017-11-12-best-boutique-hotels-paris.markdown
+++ b/_posts/2017-11-12-best-boutique-hotels-paris.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-12 00:10:36 -0400
 thumbnail: ../images/paris/paris_header.jpg
-categories: travelguide
+categories: list
 ---
 
 ![](../images/paris/paris_header.jpg)

--- a/_posts/2017-11-18-where-to-eat-bed-stuy-brooklyn.markdown
+++ b/_posts/2017-11-18-where-to-eat-bed-stuy-brooklyn.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-20 00:10:36 -0400
 thumbnail: ../images/bedstuy/bedstuy_food_header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 <p class="mt3">This is the InnBox’s first list that’s exclusively about food and boy, is it personal. I hesitate to even say these are “the best” places to eat at in Bed-Stuy, it’s more like these are the places which I often frequented during my time living in the neighborhood (so don’t be surprised if you notice a disproportionate amount of Asian restaurants featured here). Bed-Stuy is also a very big neighborhood and many of these eateries are located on the west side, closer to where I’m based and near the Bedford-Nostrand G stop as well as the Franklin Avenue C stop.

--- a/_posts/2017-11-18-where-to-stay-bed-stuy-brooklyn.markdown
+++ b/_posts/2017-11-18-where-to-stay-bed-stuy-brooklyn.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-20 00:10:36 -0400
 thumbnail: ../images/bedstuy/bedstuy_header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 <a href="https://www.flickr.com/photos/baschtelt/10782896243/" target="_blank"><img src="/images/bedstuy/bedstuy_header.jpg"></a>

--- a/_posts/2017-12-03-tromso-travel-guide.markdown
+++ b/_posts/2017-12-03-tromso-travel-guide.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-11-20 00:10:36 -0400
 thumbnail: ../images/tromso/tromso_header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 <img src="/images/tromso/tromso_header.jpg">

--- a/_posts/2017-12-10-best-airbnbs-asheville-north-carolina.markdown
+++ b/_posts/2017-12-10-best-airbnbs-asheville-north-carolina.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-12-10 00:10:36 -0400
 thumbnail: ../images/asheville/asheville_header.jpg
-categories: travel guide
+categories: list airbnb
 ---
 
 ![](../images/asheville/asheville_header.jpg)

--- a/_posts/2017-12-17-bariloche-argentina-travel-guide.markdown
+++ b/_posts/2017-12-17-bariloche-argentina-travel-guide.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2017-12-17 00:10:36 -0400
 thumbnail: ../images/bariloche/bariloche_header.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 <img src="/images/bariloche/bariloche_header.jpg">

--- a/_posts/2018-01-14-last-minute-valentines-day-escapes.markdown
+++ b/_posts/2018-01-14-last-minute-valentines-day-escapes.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-01-14 00:10:36 -0400
 thumbnail: ../images/valentines/valentines_header.jpg
-categories: travel guide
+categories: list
 ---
 
 <img src="/images/valentines/valentines_header.jpg">

--- a/_posts/2018-02-04-best-airbnbs-san-francisco.markdown
+++ b/_posts/2018-02-04-best-airbnbs-san-francisco.markdown
@@ -5,7 +5,8 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-02-04 00:10:36 -0400
 thumbnail: ../images/sf/sf_bnb_header.jpg
-categories: list
+categories: list airbnb
+related_posts: [/best-airbnbs-austin-texas, /best-airbnbs-asheville-north-carolina]
 ---
 
 <p class="pb3" style="max-width: 650px; margin: auto;">
@@ -210,29 +211,3 @@ This apartment is located in the same area of the Mission I used to live and in 
 Another East Mission abode, although this one is filled with quirky and artful little details and vintage vibes befitting of the neighborhood. The apartment itself also has a huge kitchen island for a group to gather around, and a backyard patio table for dining al fresco. A few scenes from the movie "Blue Jasmine" were even filmed in the backyard. Accommodates up to 8.</p>
 
 <p class="f6 i light-silver pb4" style="max-width: 650px; margin: auto;">This airbnb is not wheelchair accessible.</p>
-
-<p class="tc f3 pt4 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our top Airbnb picks:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb3 mb0-ns">
-  <a href="http://theinnbox.co/best-airbnbs-austin-texas/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/austin/stay_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/best-airbnbs-austin-texas/">Where to Stay in Austin, Texas— Including the 9 Best Airbnbs</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/best-airbnbs-asheville-north-carolina/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/asheville/asheville_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/best-airbnbs-asheville-north-carolina/">The 13 Best Airbnbs in Asheville, North Carolina</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-02-18-where-to-stay-palm-springs.markdown
+++ b/_posts/2018-02-18-where-to-stay-palm-springs.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-02-25 00:10:36 -0400
 thumbnail: ../images/palmsprings/ps_header.jpg
-categories: travel guide
+categories: list
 ---
 
 <img class="mt4-ns mt3 mb4-ns mb3" src="/images/palmsprings/ps_header.jpg">

--- a/_posts/2018-03-04-marina-bay-sands-singapore-review.markdown
+++ b/_posts/2018-03-04-marina-bay-sands-singapore-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "February 6, 2018"
 review_rate: 408
 review_guests: "Her Boyfriend"
+related_posts: [/birdhouse-el-nido-review, /my-love-inn-lijiang-review]
 ---
 
 
@@ -169,30 +170,4 @@ As for me, I typically think booking anywhere over $200/night range is a splurge
 <p class="lh-copy">If you found this review helpful, please use our link below to book at the Marina Bay Sands (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="http://www.booking.com/hotel/sg/marina-bay-sands.html?aid=1452227
 ">Book your stay @ The Marina Bay Sands</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/birdhouse-el-nido-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/birdhouse/1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/birdhouse-el-nido-review/">Hotel Review: The Birdhouse El Nido in Palawan, Philippines</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/my-love-inn-lijiang-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/myloveinn/1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/my-love-inn-lijiang-review/">Hotel Review: My Love Inn in Lijiang, China</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-03-18-hoi-an-travel-guide.markdown
+++ b/_posts/2018-03-18-hoi-an-travel-guide.markdown
@@ -5,7 +5,7 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-03-18 00:10:36 -0400
 thumbnail: ../images/hoian/splash.jpg
-categories: travel guide
+categories: travelguide
 ---
 
 <img class="mt4-ns mt3 mb4-ns mb3" src="/images/hoian/splash.jpg">

--- a/_posts/2018-03-25-the-slow-canggu-bali-review.markdown
+++ b/_posts/2018-03-25-the-slow-canggu-bali-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "May 10 — 12, 2018"
 review_rate: 182.67
 review_guests: "Her Best Friend"
+related_posts: [/birdhouse-el-nido-review, /marina-bay-sands-singapore-review]
 ---
 
 
@@ -139,30 +140,4 @@ I would totally recommend The Slow to any art and design lovers planning a trip 
 <div class="tc tl-ns" style="max-width: 650px; margin: auto;">
 <p class="lh-copy">If you found this review helpful, please use our link below to book at The Slow Canggu (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://www.agoda.com/partners/partnersearch.aspx?cid=1801609&pcs=1&hid=1515695">Book your stay @ The Slow</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/birdhouse-el-nido-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/birdhouse/1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/birdhouse-el-nido-review/">Hotel Review: The Birdhouse El Nido in Palawan, Philippines</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/marina-bay-sands-singapore-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/mbs/17.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/marina-bay-sands-singapore-review/">Hotel Review: The Marina Bay Sands in Singapore</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-04-01-200-dollars-airbnb-new-york-city.markdown
+++ b/_posts/2018-04-01-200-dollars-airbnb-new-york-city.markdown
@@ -5,7 +5,9 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-04-01 00:10:36 -0400
 thumbnail: ../images/nycair/Splash.jpg
-categories: list
+categories: list airbnb
+related_posts: [/best-airbnbs-san-francisco, /best-airbnbs-asheville-north-carolina]
+related_posts_custom_title: Want to see how New York Airbnbs compare with other cities?<br> Check out our other Airbnb lists
 ---
 
 <p class="pb3" style="max-width: 650px; margin: auto;">
@@ -350,29 +352,3 @@ This sun-drenched Airbnb gave me déjà vu because it has the same layout as an 
 
 <p class="f6 i light-silver pb4" style="max-width: 650px; margin: auto;">
 This Airbnb has elevator access, but we'd recommend directly contacting the host for more accessibility details.</p>
-
-<p class="tc f3 pt4 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Want to see how New York Airbnbs compare with other cities?<br>Check out our other Airbnb lists:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb3 mb0-ns">
-  <a href="http://theinnbox.co/best-airbnbs-san-francisco/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/sf/sf_bnb_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/best-airbnbs-san-francisco/">The 13 Best Airbnbs in San Francisco</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/best-airbnbs-asheville-north-carolina/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/asheville/asheville_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/best-airbnbs-asheville-north-carolina/">The 13 Best Airbnbs in Asheville, North Carolina</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-04-08-calma-ubud-bali-review.markdown
+++ b/_posts/2018-04-08-calma-ubud-bali-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "March 8 — 10, 2018"
 review_rate: 87
 review_guests: "Her Best Friend"
+related_posts: [/birdhouse-el-nido-review, /the-slow-canggu-bali-review]
 ---
 
 
@@ -151,30 +152,4 @@ If you really want to go "all out" during your stay to Ubud there are definitely
 <div class="tc tl-ns" style="max-width: 650px; margin: auto;">
 <p class="lh-copy">If you found this review helpful, please use our link below to book at Calma Ubud (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://www.agoda.com/partners/partnersearch.aspx?cid=1801609&pcs=1&hl=en&hid=1258271">Book your stay @ Calma Ubud</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/birdhouse-el-nido-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/birdhouse/1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/birdhouse-el-nido-review/">Hotel Review: The Birdhouse El Nido in Palawan, Philippines</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/the-slow-canggu-bali-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/slow/01.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/the-slow-canggu-bali-review/">Hotel Review: The Slow in Canggu, Bali</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-04-08-muji-hotel-shenzhen-review.markdown
+++ b/_posts/2018-04-08-muji-hotel-shenzhen-review.markdown
@@ -8,6 +8,7 @@ thumbnail: ../images/muji/00_Cover.jpg
 categories: review
 review_dates: "April 5 — 6, 2018"
 review_rate: 150
+related_posts: [/birdhouse-el-nido-review, /marina-bay-sands-singapore-review]
 ---
 
 <img class="mt4-ns mt3 mb4-ns mb3" src="/images/muji/00_Cover.jpg">
@@ -247,30 +248,3 @@ If you found this review helpful, please let the MUJI Hotel know when you book!<
 
 <p class="pb3" style="max-width: 650px; margin: auto;">
 Mintlodica is Susan’s creative studio. Check out her studio’s <a href="https://twitter.com/mintlodica">Twitter</a> and <a href="https://www.instagram.com/mintlodica/">Instagram</a>. If you are looking for art for your walls, check out her <a href="https://susan.level.press/">art prints shop</a>! She also offers <a href="http://mintlodica.storenvy.com/">shiba inu pixel art apparel</a> and has a <a href="http://mintlodica.tictail.com/">limited edition enamel pin</a> up for grabs.</p>
-
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/birdhouse-el-nido-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/birdhouse/1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/birdhouse-el-nido-review/">Hotel Review: The Birdhouse El Nido in Palawan, Philippines</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/marina-bay-sands-singapore-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/mbs/17.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/marina-bay-sands-singapore-review/">Hotel Review: The Marina Bay Sands in Singapore</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-04-15-providence-rhode-island-travel-guide.markdown
+++ b/_posts/2018-04-15-providence-rhode-island-travel-guide.markdown
@@ -5,7 +5,8 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-04-15 00:10:36 -0400
 thumbnail: ../images/providence/splash.jpg
-categories: travel guide
+categories: travelguide
+related_posts: [/san-luis-obispo-travel-guide, /bariloche-argentina-travel-guide]
 ---
 
 <img class="mt4-ns mt3 mb4-ns mb3" src="/images/providence/splash.jpg">
@@ -169,30 +170,4 @@ Providence. The biggest city in America's smallest state. It's a known creative 
 <p class="f4 mb1 lh-title mt0-ns mt3" style="font-family: 'Gilroy-ExtraBold'"><a href="https://foursquare.com/v/julians/4a8844dff964a520a40520e3" target="blank">Eat Eggs at Julian's</a></p>
 <p>While there are many new brunch restaurants that have cropped up in recent years in Providence's hip Federal Hill neighborhood, Julian's has been a neighborhood establishment for over twenty years. Their signature also happens to be my favorite brunch dish: Eggs Benedict. Take your pick of seven different varieties and one of their creative hash sides. If Benedicts aren't your thing the restaurant also offer you eggs wrapped, poached in shakshuka, scrambled into a pizza, or fried into an omelet. </p>
 </div>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our travel guides:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/san-luis-obispo-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/slo/SLO_Header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/san-luis-obispo-travel-guide/">Why not SLO down in San Luis Obispo for your next weekend trip?</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/bariloche-argentina-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/bariloche/bariloche_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/bariloche-argentina-travel-guide/">Your travel guide to Bariloche, Argentina: where to stay and what to do.</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-05-05-hotel-1-busan-review.markdown
+++ b/_posts/2018-05-05-hotel-1-busan-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "April 24 — 26, 2018"
 review_rate: 77
 review_guests: "Her Boyfriend"
+related_posts: [/muji-hotel-shenzhen-review, /marina-bay-sands-singapore-review]
 ---
 
 
@@ -208,30 +209,4 @@ Hotel 1 has such a fresh, youthful vibe that stills feels classy and upscale. Co
 <p class="lh-copy">
 Please use our link below to book at Gwanganli Hotel 1 (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://www.agoda.com/partners/partnersearch.aspx?pcs=1&cid=1801609&hl=en&hid=2962286">Book your stay @ Hotel 1</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/muji-hotel-shenzhen-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/muji/00_Cover.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/muji-hotel-shenzhen-review/">Hotel Review: The first ever MUJI Hotel in Shenzhen, Guangdong, China</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/marina-bay-sands-singapore-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/mbs/17.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/marina-bay-sands-singapore-review/">Hotel Review: The Marina Bay Sands in Singapore</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-05-20-sala-phuket-review.markdown
+++ b/_posts/2018-05-20-sala-phuket-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "May 8 — 10, 2018"
 review_rate: 249
 review_guests: "Her Boyfriend"
+related_posts: [/muji-hotel-shenzhen-review, /marina-bay-sands-singapore-review]
 ---
 
 
@@ -251,30 +252,4 @@ While I can't see myself doing the resort thing for every beach trip, I'm defini
 <p class="lh-copy">
 Please use our link below to book at SALA Phuket Resort & Spa (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://www.agoda.com/partners/partnersearch.aspx?pcs=1&cid=1801609&hl=en&hid=89341">Book your stay @ SALA Phuket</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/muji-hotel-shenzhen-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/muji/00_Cover.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/muji-hotel-shenzhen-review/">Hotel Review: The first ever MUJI Hotel in Shenzhen, Guangdong, China</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/marina-bay-sands-singapore-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/mbs/17.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/marina-bay-sands-singapore-review/">Hotel Review: The Marina Bay Sands in Singapore</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-06-24-how-to-see-it-all-while-traveling.markdown
+++ b/_posts/2018-06-24-how-to-see-it-all-while-traveling.markdown
@@ -5,7 +5,8 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-06-23 00:10:36 -0400
 thumbnail: ../images/seeitall/00.jpg
-categories: travel guide
+categories: travelguide
+related_posts: [/bariloche-argentina-travel-guide, /granada-nicaragua-travel-guide]
 ---
 
 
@@ -137,29 +138,3 @@ If you are going to visit multiple sites in a day, multiple neighborhoods in a w
 <p class="tc mid-gray mb3 mb4-ns i f7">Gamcheon Cultural Village in Busan, South Korea. Tourist-y? Yes. Worth it? Yes. Plus conveniently located on a circuit with fellow attractions Taejongdae Park and BIFF Square.</p>
 
 <p class="pb3 pb4-ns" style="max-width: 650px; margin: auto;">I hope this helps reduce some of the stress and anxiety associated with planning itineraries, but if all else fails just remember this: you're going somewhere different from your day to day so it's going to be exciting no matter what. Even if you don't see any major tourist attractions. Even if it that's all you see. At the end of the day it's still a vacation and the only way you can mess that up is if you forget to delete Slack from your phone.</p>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of my travel guides:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/bariloche-argentina-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/bariloche/bariloche_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/bariloche-argentina-travel-guide/">Your travel guide to Bariloche, Argentina: where to stay and what to do.</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/granada-nicaragua-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/granada/NICA_HEADER.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/granada-nicaragua-travel-guide/">Your travel guide to Granada, Nicaragua: where to stay and what to do.</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-07-02-the-aviary-hotel-siem-reap-review.markdown
+++ b/_posts/2018-07-02-the-aviary-hotel-siem-reap-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "June 26 — 28, 2018"
 review_rate: 73
 review_guests: "Her Boyfriend"
+related_posts: [/hotel-1-busan-review, /marina-bay-sands-singapore-review]
 ---
 
 
@@ -190,30 +191,4 @@ I would highly recommend The Aviary Hotel to anyone visiting Siem Reap. I think 
 <p class="lh-copy">
 Please use our link below to book at The Aviary Hotel (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://www.agoda.com/partners/partnersearch.aspx?pcs=1&cid=1801609&hl=en&hid=1119219">Book your stay @ The Aviary Hotel</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/hotel-1-busan-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/hotel1/04.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/hotel-1-busan-review/">Hotel Review: Hotel 1 in Busan, South Korea</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/marina-bay-sands-singapore-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/mbs/17.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/marina-bay-sands-singapore-review/">Hotel Review: The Marina Bay Sands in Singapore</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-07-19-the-algarve-portugal-travel-guide.markdown
+++ b/_posts/2018-07-19-the-algarve-portugal-travel-guide.markdown
@@ -5,7 +5,8 @@ author: Joanne Yae
 author_ig: jyae7777
 date:   2018-07-19 00:10:36 -0400
 thumbnail: ../images/algarve/00.jpg
-categories: review
+categories: travelguide
+related_posts: [/bariloche-argentina-travel-guide, /granada-nicaragua-travel-guide]
 ---
 
 <img class="mt4-ns mt3 mb4-ns mb3" src="/images/algarve/00.jpg">
@@ -180,29 +181,3 @@ Train is the best way to get here from Lagos, and it is an 1hr 40 min ride.  Onc
 
 <p class="pb3" style="max-width: 650px; margin: auto;">
 Joanne is a developer and surfer girl wannabe based in NYC with a serious skill for getting the perfect tan.  She enjoys seafood, travel photography, and flights paid with points.  Her upcoming travel plans include Hawaii in August and New Zealand in November, with lots of Miami in between. You can follow her travels on <a href="https://www.instagram.com/jyae7777/" target="blank">Instagram</a>, her <a href="https://www.instagram.com/jyae7777/" target="blank">Travel Photo Blog</a>, or <a href="yae.joanne@gmail.com">contact her directly</a>.</p>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our travel guides:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/bariloche-argentina-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/bariloche/bariloche_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/bariloche-argentina-travel-guide/">Your travel guide to Bariloche, Argentina: where to stay and what to do.</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/granada-nicaragua-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/granada/NICA_HEADER.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/granada-nicaragua-travel-guide/">Your travel guide to Granada, Nicaragua: where to stay and what to do.</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-07-30-travel-like-a-type-b-corsica-france.markdown
+++ b/_posts/2018-07-30-travel-like-a-type-b-corsica-france.markdown
@@ -6,6 +6,8 @@ author_ig: therelzoe
 date:   2018-07-28 00:10:36 -0400
 thumbnail: ../images/typeb/15.jpg
 categories: longform
+related_posts: [/how-to-see-it-all-while-traveling, /200-dollars-airbnb-new-york-city]
+related_posts_custom_title: Check out more of our travel posts
 ---
 
 
@@ -205,29 +207,3 @@ There are all sorts of vacations you could take; cities like Paris, beaches like
 
 <p class="pb3" style="max-width: 650px; margin: auto;">
 Arielle works in Product by day and spends her free time exploring her own city, New York, and planning trips to off the beaten path locales before they become the hot new thing. She’s a sucker for French pastries and ethnic eats. Her next trips include Copenhagen for some summertime hygge and Bolivian salt flats for some 4x4 adventuring. You can follow her travels <a href="https://www.instagram.com/therelzoe/">on Instagram.</a></p>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our travel posts:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/how-to-see-it-all-while-traveling/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/seeitall/00.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/how-to-see-it-all-while-traveling/">How I make time to 'see it all' when I travel</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/200-dollars-airbnb-new-york-city/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/nycair/Splash.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/200-dollars-airbnb-new-york-city/">Here's what $200 on Airbnb can get you in New York City</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-08-05-busaba-ayutthaya-review.markdown
+++ b/_posts/2018-08-05-busaba-ayutthaya-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "June 18 — 19, 2018"
 review_rate: 54
 review_guests: "Three Companions"
+related_posts: [/hotel-1-busan-review, /my-love-inn-lijiang-review]
 ---
 
 
@@ -168,30 +169,4 @@ I highly recommend the Busaba for those on a budget who still want to stay somew
 <p class="lh-copy">
 Please use our link below to book at Busaba Ayutthaya (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://www.agoda.com/partners/partnersearch.aspx?pcs=1&cid=1801609&hid=4489474">Book your stay @ Busaba Ayutthaya</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/hotel-1-busan-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('../images/hotel1/04.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/hotel-1-busan-review/">Hotel Review: Hotel 1 in Busan, South Korea</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/my-love-inn-lijiang-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/myloveinn/1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/my-love-inn-lijiang-review/">Hotel Review: My Love Inn in Lijiang, China</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-08-19-hokkaido-road-trip-itinerary-and-guide.markdown
+++ b/_posts/2018-08-19-hokkaido-road-trip-itinerary-and-guide.markdown
@@ -5,7 +5,8 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-08-18 00:10:36 -0400
 thumbnail: ../images/hokkaido-2/AKA_1.jpg
-categories: list
+categories: travelguide
+related_posts: [/san-luis-obispo-travel-guide, /why-right-now-is-actually-a-good-and-helpful-time-to-visit-mexico-city]
 ---
 
 
@@ -336,30 +337,3 @@ The next morning we dropped our car off at the OTS lot in the airport and a shut
 </li>
 </li>
 </ul>
-
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our travel guides:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/san-luis-obispo-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/slo/SLO_Header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/san-luis-obispo-travel-guide/">Why not SLO down in San Luis Obispo for your next weekend trip?</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/why-right-now-is-actually-a-good-and-helpful-time-to-visit-mexico-city/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/mexicocity/MexicoCity_Header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/why-right-now-is-actually-a-good-and-helpful-time-to-visit-mexico-city/">Why right now is actually a good and most helpful time to visit Mexico City</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-09-09-the-marshall-house-savannah-georgia-review.markdown
+++ b/_posts/2018-09-09-the-marshall-house-savannah-georgia-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "May 30 — June 1, 2018"
 review_rate: 161
 review_guests: "Her Best Friend"
+related_posts: [/the-slow-canggu-bali-review, /the-aviary-hotel-siem-reap-review]
 ---
 
 <img class="mt4-ns mt3 mb4-ns mb3" src="/images/marshall/00.jpg">
@@ -147,30 +148,4 @@ If I were to go back to Savannah I’d probably want to stay in a less central l
 <p class="lh-copy">
 Please use our link below to book at The Marshall House (or any other hotel!). The InnBox may collect a small share of sales.</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://www.booking.com/hotel/us/the-marshall-house.en.html?aid=1452227">Book your stay @ The Marshall House</a>
-</div>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/the-slow-canggu-bali-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/slow/01.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/the-slow-canggu-bali-review/">Hotel Review: The Slow in Canggu, Bali</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/the-aviary-hotel-siem-reap-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/aviary/00.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/the-aviary-hotel-siem-reap-review/">Hotel Review: The Aviary Hotel in Siem Reap, Cambodia</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-09-23-best-places-to-stay-upstate-new-york.markdown
+++ b/_posts/2018-09-23-best-places-to-stay-upstate-new-york.markdown
@@ -6,6 +6,8 @@ author_ig: sabrinasans
 date:   2018-09-23 00:10:36 -0400
 thumbnail: ../images/upstate/arnold_1.jpg
 categories: list
+related_posts: [/best-boutique-hotels-paris, /where-to-stay-palm-springs]
+related_posts_custom_title: "Check out more of our where-to-stay roundups"
 ---
 
 
@@ -364,29 +366,3 @@ I saved my personal favorite for last. This Hudson property was originally built
 
 <p class="f6 i light-silver pb4" style="max-width: 650px; margin: auto;">
 One of This Old Hudson's units is located on the ground floor, but we recommend reaching out directly to the host for more accessibility details.</p>
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our where-to-stay roundups:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/best-boutique-hotels-paris/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/paris/paris_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/best-boutique-hotels-paris/">The 7 best boutique hotels in Paris under $300</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/where-to-stay-palm-springs/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/palmsprings/ps_header.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/where-to-stay-palm-springs/">8 Places to Stay in Palm Springs that aren't the Ace Hotel & Pool Club</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>

--- a/_posts/2018-10-08-le-pirate-boatel-labuan-bajo-review.markdown
+++ b/_posts/2018-10-08-le-pirate-boatel-labuan-bajo-review.markdown
@@ -9,6 +9,7 @@ categories: review
 review_dates: "September 15 — 18, 2018"
 review_rate: 43
 review_guests: "Her Boyfriend"
+related_posts: [/what-hokkaido-taught-me-about-hospitality, birdhouse-el-nido-review]
 ---
 
 <img class="mt4-ns mt3 mb4-ns mb3" src="/images/boatel/00.jpg">
@@ -177,31 +178,4 @@ Le Pirate also offers a cruise-like experience in Labuan Bajo on a smaller boat 
 <div class="tc tl-ns" style="max-width: 650px; margin: auto;">
 <p class="lh-copy">If you found this review helpful, please let Le Pirate know when you book!</p>
 <a target="_blank" class="f5 link ba bw1 ph3 pv2 mb2 dib orange" href="https://lepirate.com/boatel/" target="new">Book your stay @ Le Pirate Boatel</a>
-</div>
-
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our hotel reviews:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/what-hokkaido-taught-me-about-hospitality/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/hokkaido/hokkaidolodging_thumb.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/what-hokkaido-taught-me-about-hospitality/">What Hokkaido taught me about hospitality</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/birdhouse-el-nido-review/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/birdhouse/1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/birdhouse-el-nido-review/">Hotel Review: The Birdhouse El Nido in Palawan, Philippines</a>
-      </h2>
-    </div>
-  </div>
-</a>
 </div>

--- a/_posts/2018-10-21-labuan-bajo-day-trip-diary.markdown
+++ b/_posts/2018-10-21-labuan-bajo-day-trip-diary.markdown
@@ -5,7 +5,8 @@ author: Sabrina Majeed
 author_ig: sabrinasans
 date:   2018-10-21 00:10:36 -0400
 thumbnail: ../images/lb/01.jpg
-categories: list
+categories: list travelguide
+related_posts: [/hokkaido-road-trip-itinerary-and-guide, /granada-nicaragua-travel-guide]
 ---
 
 <img class="mt3-ns mt3 mb4-ns mb3" src="../images/lb/00.jpg">
@@ -163,30 +164,3 @@ Julius opted to just sit higher up on the beach in the shade (where we found the
 
 <p class="pb3 pb4-ns" style="max-width: 650px; margin: auto;">
 I would highly recommend the Red Whale island tour to anyone visiting Labuan Bajo. For one, it's pretty rare for a tour like this to go to six different places so I felt like we got a good value out of the tour. I also felt like 12 people was a good amount of people for a group tour. It felt more intimate than other tours we had been on, but less awkward than the group tours where it's been just us and one or two other couples. The Red Whale boats are also quite clean and cute looking— with an iconic red color and a sun deck on top. The guides were a little less extroverted than some of the ones I've encountered on similar tours in Thailand and the Philippines but they were by no means unfriendly— and one of them truly had an eye for photography and was always volunteering to take photos of the various couples amongst the group. Red Whale can be easily reached through WhatsApp if you want to book a tour in advance, or you can easily walk to their office near Labuan Bajo harbor to book in person.</p>
-
-
-<p class="tc f3 pt5 pb3 lh-title" style="font-family: 'Gilroy-ExtraBold'">Check out more of our travel guides and itineraries:</p>
-
-<div class="fl w-100 w-50-ns pr2-ns mb4">
-  <a href="http://theinnbox.co/hokkaido-road-trip-itinerary-and-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/hokkaido-2/AKA_1.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/hokkaido-road-trip-itinerary-and-guide/">Traversing Hokkaido in 8 days: a road trip itinerary and travel guide</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>
-
-<div class="fl w-100 w-50-ns pl2-ns mb1 mb0-ns">
-  <a href="http://theinnbox.co/granada-nicaragua-travel-guide/"><div class="relative" style="height: 450px; background-color:#ECEAE7;">
-    <div class="bg-center cover" style="background-image: url('http://theinnbox.co/images/granada/NICA_HEADER.jpg'); padding-bottom:100%; width:100%;"></div>
-    <div class="absolute bottom-2 bg-white pv3 ph4 mh4">
-      <h2 style="font-family: 'Inconsolata', monospace;" class="mb1">
-      <a class="f5 lh-title post-link" href="http://theinnbox.co/granada-nicaragua-travel-guide/">Your travel guide to Granada, Nicaragua: where to stay and what to do</a>
-      </h2>
-    </div>
-  </div>
-</a>
-</div>


### PR DESCRIPTION
- Adds support for providing `related_posts: [/post-name-here, /post-name-here]` as an array
- Titles for related posts section depends on `categories`, e.g. `review`, `travelguide`
- Adds support for providing a custom title `related_posts_custom_title` (no colon needed, supports inline HTML like `<br>`)
- Changed the category `travel guide` to `travelguide` because `categories` actually turns `travel guide` into an array of two separate tags: `[travel, guide]`. Alternatively, we can use make all frontmatter use `["travel guide"]` but I got lazy. Or use `travel-guide`. Easy to search and replace now.

<img width="979" alt="screen shot 2018-10-28 at 1 24 35 pm" src="https://user-images.githubusercontent.com/1629901/47612812-d528f600-dab4-11e8-8f51-46d0d892bf17.png">

---

**Future work**
- We can actually source the related posts automatically based on the category tags, e.g. if you're looking at a `review`, we can automatically pull the two most recent/two random other `review` tagged posts. This would've actually been easier to implement with fewer lines of code, but I assumed you curated some of these posts on purpose, and also the tagging wasn't clean.
- It would be good to codify `list` and `airbnb` tags, and have those correspond to the proper categories with titles, e.g. you use "roundup" in the articles sometimes, is that the same as `list`? What about `longform`, should we codify that? Or are longforms almost always also `travelguide`s?